### PR TITLE
Fix support for `no_std` environment

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,4 +1,8 @@
 use crate::parser::{Error, Position};
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 

--- a/src/json.rs
+++ b/src/json.rs
@@ -1,9 +1,15 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use crate::parser::{
     Concat, Concat3, Either, Error, Input, OneOf, OneOrMore, Parser, ResultOf, ZeroOrMore,
     ZeroOrOne,
 };
 use crate::{literals, parsers};
-use std::convert::TryInto;
+use core::convert::TryInto;
 
 literals! {
     pub WhitespaceChar => '\u{0020}' | '\u{000D}' | '\u{000A}' | '\u{0009}';


### PR DESCRIPTION
Adding `simple-json` in a Substrate Runtime failed to compile Wasm.

This should fix that.

https://github.com/jimmychu0807/substrate-offchain-pricefetch/issues/2