### PR TITLE
Fix unused import warning in std-enabled case

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -5,6 +5,7 @@ extern crate alloc;
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]
 use crate::parser::alloc::fmt::Formatter;
 
 #[cfg_attr(feature = "std", derive(Debug))]


### PR DESCRIPTION
Fixes
```
warning: unused import: `crate::parser::alloc::fmt::Formatter`
 --> src/impls.rs:8:5
  |
8 | use crate::parser::alloc::fmt::Formatter;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

    Finished dev [unoptimized + debuginfo] target(s) in 0.38s
```