### PR TITLE
Sync package name with the published one

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "simple-json"
+name = "lite-json"
 version = "0.1.0"
 authors = ["Bryan Chen <xlchen1291@gmail.com>"]
 edition = "2018"


### PR DESCRIPTION
As per https://crates.io/crates/lite-json