### PR TITLE
Add a convenience no_std method to get a f64 out of NumberValue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,10 @@ edition = "2018"
 
 [dependencies]
 paste = "0.1"
+num-traits = { version = "0.2", optional = true, default-features = false }
 
 [features]
 default = ["std"]
 std = []
+# Enables converting values to floats in no-`std` environment
+float = ["num-traits"]

--- a/src/json.rs
+++ b/src/json.rs
@@ -203,9 +203,20 @@ pub struct NumberValue {
     pub exponent: i32,
 }
 
-#[cfg(feature = "std")]
+impl NumberValue {
+    /// Losslessly convert the inner value to `f64`.
+    #[cfg(any(feature = "std", feature = "float"))]
+    pub fn to_f64(self) -> f64 {
+        self.into()
+    }
+}
+
+#[cfg(any(feature = "std", feature = "float"))]
 impl Into<f64> for NumberValue {
     fn into(self) -> f64 {
+        #[cfg(not(feature = "std"))]
+        use num_traits::float::FloatCore as _;
+
         (self.integer as f64 + self.fraction as f64 / 10f64.powi(self.fraction_length as i32))
             * 10f64.powi(self.exponent)
     }


### PR DESCRIPTION
This is purely for the sake of convenience so the users wouldn't need to pull `num-traits` and do the respective operations themselves in a `no_std` float-enabled environment like WebAssembly.