### PR TITLE
Fix noncompiling matchers in `literals` macro

### DIFF
--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -223,28 +223,28 @@ macro_rules! literals {
     (
         $(
             $( #[ $attr:meta ] )*
-            $vis:vis $name:ident => $($value:expr)+;
+            $vis:vis $name:ident => $($($value:literal)..=+)|+;
         )*
     ) => {
         $(
             $crate::literals!{
                 IMPL
                 $( #[ $attr ] )*
-                $vis $name => $($value)+
+                $vis $name => $($($value)..=+)|+
             }
         )*
     };
     (
         IMPL
         $( #[ $attr:meta ] )*
-        $vis:vis $name:ident => $($value:tt)+
+        $vis:vis $name:ident => $($($value:literal)..=+)|+
     ) => (
         $crate::paste::item! {
             $vis struct [< $name Predicate >];
             impl $crate::parser::Predicate<char> for [< $name Predicate >] {
                 fn eval(c: &char) -> bool {
                     match *c {
-                        $($value)+ => true,
+                        $($($value)..=+)|+ => true,
                         _ => false
                     }
                 }

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -225,22 +225,22 @@ macro_rules! literals {
             $( #[ $attr:meta ] )*
             $vis:vis $name:ident => $($value:expr)+;
         )*
-	) => {
-	    $(
-	        $crate::literals!{
-	            IMPL
+    ) => {
+        $(
+            $crate::literals!{
+                IMPL
                 $( #[ $attr ] )*
                 $vis $name => $($value)+
             }
-	    )*
-	};
-	(
-	    IMPL
+        )*
+    };
+    (
+        IMPL
         $( #[ $attr:meta ] )*
         $vis:vis $name:ident => $($value:tt)+
-	) => (
-	    $crate::paste::item! {
-	        $vis struct [< $name Predicate >];
+    ) => (
+        $crate::paste::item! {
+            $vis struct [< $name Predicate >];
             impl $crate::parser::Predicate<char> for [< $name Predicate >] {
                 fn eval(c: &char) -> bool {
                     match *c {
@@ -252,8 +252,8 @@ macro_rules! literals {
 
             $( #[ $attr ] )*
             $vis type $name = $crate::parser::ExpectChar<[< $name Predicate >]>;
-	    }
-	);
+        }
+    );
 }
 
 #[macro_export]


### PR DESCRIPTION
It's possible this was hitting a compiler bug before, but for whatever reason the `literals` macro doesn't seem to work as written. See https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=d0c8d46f71a62369c5e2709181e7f046 for analogous code extracted out to the playground.

This PR changes the matcher for $value from `$($value:expr)+` to `$($($value:literal)..=+)|+` which does work -- see https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=b6fd7a18f6ed0a5c94f892ab100a5d11.