### PR TITLE
Add `no_std` to lite-parser

### DIFF
--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 pub mod impls;
 pub mod parser;
 pub mod traits;


### PR DESCRIPTION
I couldn't build with `no_std` while lite-parser didn't have `no_std` configuration in it's `lib.rs` file.