### PR TITLE
Permit empty arrays via OneOf.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lite-json"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Bryan Chen <xlchen1291@gmail.com>"]
 description = "Simple JSON parser. Wasm / no_std ready."
 license = "Apache-2.0"


### PR DESCRIPTION
Adds a test case to verify the failure in parsing empty arrays, and fixes it using `OneOf`, to parallel curly bracket object parsing.